### PR TITLE
Support for TLS v1.3 + some internal improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,9 +19,11 @@ env:
   global:
     - secure: c2jbo4LdwlTIT2eKdhWCMV7WREyDoRjRQs3AJkRddb1cyvvkuuDXkIu5elzbesuNyFq8g2YLrBv3hk65eBz0lH7+/ASCPF+F9uHZr9jWv1+oUJRcVueW8L+5se+KsbyAF718s+HiUr8lWNdsuZTFfRutngZfYKMBJbq82Xr4dCSHkyyFTUcNaBvJBSmGO1r4M9vF69uXhhl/IcAmMrOq8bM4rRD0AWM6YQ8DkYNTrnzcmcxc6Ljn7/xlCEBc1azEI9HdU3m+7W6MsLmcS9b3eUhGLzQ4cQ6qvZH5m25ZGEXs0Ae+X2RqRmD5+bsi5YPEDggCmbGsaC23ZwZ3prJeWPGP7/SycxNtSCO1yq+JgbTkNfL4zjxPUEBxpMpSPFEbSblDoKUjE8XzDTzeLsSeGfFxVCRrG05HOgUHW5epV2hJNEcTeGoMabC5IXt3rBDyzxw7pk2KqiR7xV7E5rj4nrlSmjWtKX9deQIpO2N3U53pLSmF8mzXBT0T9GviHnmFqfpV0kWuvvpbDa90Zk4thPL21lDdcPBS1NATYYN20071oRLntS1GsWeeEhjBYCQbrmHDoyBxf5hoxvt75omDsLaha7IVjOt9Gt3Vc46AyVRjgvF/9JazznRb8xRrL1JU4iIUUgH9hVtMleWwrgsT7hUE0Pom0qAgOEwdgKqmYBo=
   matrix:
-    - FLAVOR=tsuru NGINX_VERSION=1.14.0
-    - FLAVOR=tsuru NGINX_VERSION=1.15.0
+    - FLAVOR=tsuru NGINX_VERSION=latest
+    - FLAVOR=tsuru NGINX_VERSION=stable
     - FLAVOR=tsuru NGINX_VERSION=1.16.0
+  allow_failures:
+    - env: FLAVOR=tsuru NGINX_VERSION=latest
 matrix:
   fast_finish: true
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ env:
   matrix:
     - FLAVOR=tsuru NGINX_VERSION=latest
     - FLAVOR=tsuru NGINX_VERSION=stable
-    - FLAVOR=tsuru NGINX_VERSION=1.16.0
+    - FLAVOR=tsuru NGINX_VERSION=1.16.1
   allow_failures:
     - env: FLAVOR=tsuru NGINX_VERSION=latest
 matrix:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG nginx_version=1.16.0
+ARG nginx_version=1.16.1
 FROM nginx:${nginx_version} AS build
 
 SHELL ["/bin/bash", "-c"]
@@ -7,22 +7,7 @@ RUN set -x \
     && apt-get update \
     && apt-get install -y --no-install-suggests \
        libluajit-5.1-dev libpam0g-dev zlib1g-dev libpcre3-dev \
-       libexpat1-dev git curl build-essential libxml2 libxslt1.1 libxslt1-dev autoconf libtool \
-       # required for building and testing the OpenSSL from source
-       perl libtext-template-perl libtest-http-server-simple-perl
-
-ARG openssl_version=1.1.1c
-RUN set -x \
-    && curl -fsSL "https://www.openssl.org/source/openssl-${openssl_version}.tar.gz" \
-    |  tar -C /usr/local/src -xzvf- \
-    && ln -s /usr/local/src/openssl-${openssl_version} /usr/local/src/openssl \
-    && cd /usr/local/src/openssl \
-    && ./config \
-    && make \
-    && make test \
-    && make install \
-    && ldconfig -v \
-    && openssl version -a
+       libexpat1-dev git curl build-essential libxml2 libxslt1.1 libxslt1-dev autoconf libtool libssl-dev
 
 ARG modsecurity_version=v3.0.3
 RUN set -x \
@@ -37,7 +22,7 @@ RUN set -x \
 
 ARG owasp_modsecurity_crs_version=v3.1.0
 RUN set -x \
-    && nginx_modsecurity_conf_dir="/etc/nginx/conf.d/modsecurity" \
+    && nginx_modsecurity_conf_dir="/usr/local/etc/modsecurity" \
     && mkdir -p ${nginx_modsecurity_conf_dir} \
     && cd ${nginx_modsecurity_conf_dir} \
     && curl -fSL "https://github.com/SpiderLabs/owasp-modsecurity-crs/archive/${owasp_modsecurity_crs_version}.tar.gz" \
@@ -78,20 +63,12 @@ RUN set -x \
     && cd /usr/local/src/lua-resty-core \
     && make install
 
+ARG modules
 RUN set -x \
     && nginx_version=$(echo ${NGINX_VERSION} | sed 's/-.*//g') \
     && curl -fSL "https://nginx.org/download/nginx-${nginx_version}.tar.gz" \
     |  tar -C /usr/local/src -xzvf- \
     && ln -s /usr/local/src/nginx-${nginx_version} /usr/local/src/nginx \
-    && cd /usr/local/src/nginx \
-    && configure_args=$(nginx -V 2>&1 | grep 'configure arguments:' | awk -F 'configure arguments: ' '{print $2}') \
-    && eval ./configure ${configure_args} \
-    && make \
-    && make install \
-    && nginx -V 2>&1
-
-ARG modules
-RUN set -x \
     && cd /usr/local/src/nginx \
     && configure_args=$(nginx -V 2>&1 | grep "configure arguments:" | awk -F 'configure arguments:' '{print $2}'); \
     IFS=','; \
@@ -123,19 +100,16 @@ RUN set -x \
     && cp -v objs/*.so /usr/lib/nginx/modules/
 
 RUN set -x \
-    && strip --strip-unneeded /usr/local/bin/*[^c_rehash] /usr/local/lib/*.a /usr/local/lib/*.so* /usr/lib/nginx/modules/*.so
+    && strip --strip-unneeded /usr/local/bin/* /usr/local/lib/*.a /usr/local/lib/*.so* /usr/lib/nginx/modules/*.so
 
 FROM nginx:${nginx_version}
 
 COPY --from=build /usr/local/bin      /usr/local/bin
 COPY --from=build /usr/local/include  /usr/local/include
 COPY --from=build /usr/local/lib      /usr/local/lib
-COPY --from=build /usr/local/ssl      /usr/local/ssl
+COPY --from=build /usr/local/etc      /usr/local/etc
 
-COPY --from=build /usr/sbin/nginx        /usr/sbin/nginx
 COPY --from=build /usr/lib/nginx/modules /usr/lib/nginx/modules
-
-COPY --from=build /etc/nginx/conf.d/modsecurity /etc/nginx/conf.d/modsecurity
 
 ENV LUAJIT_LIB=/usr/local/lib \
     LUAJIT_INC=/usr/local/include/luajit

--- a/Dockerfile
+++ b/Dockerfile
@@ -159,6 +159,15 @@ RUN set -x \
     && rm -rf /var/lib/apt/lists/* \
     && ldconfig -v \
     && ls /etc/nginx/modules/*.so | grep -v debug \
-      | xargs -I{} sh -c 'echo "load_module {};" | tee -a  /etc/nginx/modules/all.conf'
+    |  xargs -I{} sh -c 'echo "load_module {};" | tee -a  /etc/nginx/modules/all.conf' \
+    && sed -i -E 's|listen\s+80|&80|g' /etc/nginx/conf.d/default.conf \
+    && ln -sf /dev/stdout /var/log/modsec_audit.log \
+    && touch /var/run/nginx.pid \
+    && mkdir -p /var/cache/nginx \
+    && chown -R nginx:nginx /etc/nginx /var/log/nginx /var/cache/nginx /var/run/nginx.pid /var/log/modsec_audit.log
+
+EXPOSE 8080 8443
+
+USER nginx
 
 WORKDIR /etc/nginx

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,6 +39,7 @@ RUN export NGINX_RAW_VERSION=$(echo $NGINX_VERSION | sed 's/-.*//g') \
         dirname=$(echo "${module_repo}" | sed -E 's@^.*/|\..*$@@g'); \
         git clone "${module_repo}"; \
         cd ${dirname}; \
+        git fetch --tags; \
         if [ -n "${module_tag}" ]; then \
             if [[ "${module_tag}" =~ ^(pr-[0-9]+.*)$ ]]; then \
                 pr_numbers="${BASH_REMATCH[1]//pr-/}"; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,36 +1,44 @@
 ARG nginx_version=1.16.0
-
 FROM nginx:${nginx_version} AS build
-
-ARG modsecurity_version=v3.0.3
-ARG owasp_modsecurity_crs_version=v3.1.0
 
 SHELL ["/bin/bash", "-c"]
 
-RUN apt-get update \
+RUN set -x \
+    && apt-get update \
     && apt-get install -y --no-install-suggests \
        libluajit-5.1-dev libpam0g-dev zlib1g-dev libpcre3-dev \
-       libexpat1-dev git curl build-essential libxml2 libxslt1.1 libxslt1-dev autoconf libtool libssl-dev \
-    && export NGINX_RAW_VERSION=$(echo $NGINX_VERSION | sed 's/-.*//g') \
-    && curl -fSL https://nginx.org/download/nginx-$NGINX_RAW_VERSION.tar.gz -o nginx.tar.gz \
-    && tar -zxC /usr/src -f nginx.tar.gz
+       libexpat1-dev git curl build-essential libxml2 libxslt1.1 libxslt1-dev autoconf libtool libssl-dev
 
-RUN git clone https://github.com/SpiderLabs/ModSecurity.git && cd ModSecurity && git checkout ${modsecurity_version} \
-    && git submodule init && git submodule update && ./build.sh && ./configure && make && make install
+ARG modsecurity_version=v3.0.3
+RUN set -x \
+    && git clone --depth 1 -b ${modsecurity_version} https://github.com/SpiderLabs/ModSecurity.git /usr/local/src/modsecurity \
+    && cd /usr/local/src/modsecurity \
+    && git submodule init \
+    && git submodule update \
+    && ./build.sh \
+    && ./configure \
+    && make \
+    && make install
 
-RUN strip /usr/local/modsecurity/bin/* /usr/local/modsecurity/lib/*.a /usr/local/modsecurity/lib/*.so*
-
-RUN nginx_modsecurity_conf_dir="/etc/nginx/conf.d/modsecurity" \
+ARG owasp_modsecurity_crs_version=v3.1.0
+RUN set -x \
+    && nginx_modsecurity_conf_dir="/etc/nginx/conf.d/modsecurity" \
     && mkdir -p ${nginx_modsecurity_conf_dir} \
     && cd ${nginx_modsecurity_conf_dir} \
-    && curl -fSL "https://github.com/SpiderLabs/owasp-modsecurity-crs/archive/${owasp_modsecurity_crs_version}.tar.gz" | tar -xvzf - \
+    && curl -fSL "https://github.com/SpiderLabs/owasp-modsecurity-crs/archive/${owasp_modsecurity_crs_version}.tar.gz" \
+    |  tar -xvzf - \
     && mv owasp-modsecurity-crs{-${owasp_modsecurity_crs_version#v},} \
     && cd -
 
-ARG modules
+RUN set -x \
+    && nginx_version=$(echo ${NGINX_VERSION} | sed 's/-.*//g') \
+    && curl -fSL "https://nginx.org/download/nginx-${nginx_version}.tar.gz" \
+    |  tar -C /usr/local/src -xzvf- \
+    && ln -s /usr/local/src/nginx-${nginx_version} /usr/local/src/nginx
 
-RUN export NGINX_RAW_VERSION=$(echo $NGINX_VERSION | sed 's/-.*//g') \
-    && cd /usr/src/nginx-$NGINX_RAW_VERSION \
+ARG modules
+RUN set -x \
+    && cd /usr/src/nginx \
     && configure_args=$(nginx -V 2>&1 | grep "configure arguments:" | awk -F 'configure arguments:' '{print $2}'); \
     IFS=','; \
     for module in ${modules}; do \
@@ -60,6 +68,8 @@ RUN export NGINX_RAW_VERSION=$(echo $NGINX_VERSION | sed 's/-.*//g') \
     && make modules \
     && mkdir /modules \
     && cp $(pwd)/objs/*.so /modules
+
+RUN strip /usr/local/modsecurity/bin/* /usr/local/modsecurity/lib/*.a /usr/local/modsecurity/lib/*.so*
 
 FROM nginx:${nginx_version}
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-nginx_version ?= 1.16.0
+nginx_version ?= 1.16.1
 cached_layers ?= true
 
 all:

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ image:
 
 test: image
 	@docker rm -f test-tsuru-nginx-$(flavor)-$(nginx_version) || true
-	@docker create -p 8888:80 --name test-tsuru-nginx-$(flavor)-$(nginx_version) tsuru/nginx-$(flavor):$(nginx_version) bash -c " \
+	@docker create -p 8888:8080 --name test-tsuru-nginx-$(flavor)-$(nginx_version) tsuru/nginx-$(flavor):$(nginx_version) bash -c " \
 	openssl req -x509 -newkey rsa:4096 -nodes -subj '/CN=localhost' -keyout /etc/nginx/key.pem -out /etc/nginx/cert.pem -days 365; \
 	nginx -c /etc/nginx/nginx-$(flavor).conf"
 	@docker cp $$PWD/test/nginx-$(flavor).conf test-tsuru-nginx-$(flavor)-$(nginx_version):/etc/nginx/
@@ -23,10 +23,9 @@ test: image
 	@docker start test-tsuru-nginx-$(flavor)-$(nginx_version) && sleep 3
 	@if [ "$$(curl http://localhost:8888)" != "nginx config check ok" ]; then \
 		$$(docker logs test-tsuru-nginx-$(flavor)-$(nginx_version)); \
-		docker rm -f test-tsuru-nginx-$(flavor)-$(nginx_version) || true; \
+		@docker rm -f test-tsuru-nginx-$(flavor)-$(nginx_version) || true \
 		exit 1; \
 	fi
-	@docker rm -f test-tsuru-nginx-$(flavor)-$(nginx_version) || true
-
+	@docker rm -f test-tsuru-nginx-$(flavor)-$(nginx_version) || true; \
 
 .PHONY: all flavor test

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ URLs.
 To build a flavor you can use the provided Makefile:
 
 ```
-make image flavor=tsuru nginx_version=1.16.0
+make image flavor=tsuru nginx_version=1.16.1
 ```
 
 To build a flavor, `jq` is required, cf. [download section of jq](https://stedolan.github.io/jq/download/)

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ URLs.
 To build a flavor you can use the provided Makefile:
 
 ```
-make image flavor=tsuru nginx_version=1.14.0
+make image flavor=tsuru nginx_version=1.16.0
 ```
 
 To build a flavor, `jq` is required, cf. [download section of jq](https://stedolan.github.io/jq/download/)

--- a/flavors.json
+++ b/flavors.json
@@ -5,10 +5,10 @@
       "modules": [
         "https://github.com/openresty/headers-more-nginx-module.git",
         "https://github.com/FRiCKLE/ngx_cache_purge.git:pr-45",
-        "https://github.com/simplresty/ngx_devel_kit.git",
+        "https://github.com/simplresty/ngx_devel_kit.git:v0.3.0",
         "https://github.com/openresty/echo-nginx-module.git",
         "https://github.com/wandenberg/nginx-push-stream-module.git",
-        "https://github.com/openresty/lua-nginx-module.git",
+        "https://github.com/openresty/lua-nginx-module.git:v0.10.15",
         "https://github.com/masterzen/nginx-upload-progress-module.git",
         "https://github.com/vozlt/nginx-module-vts.git:v0.1.18",
         "https://github.com/aperezdc/ngx-fancyindex.git",

--- a/test/nginx-echo.conf
+++ b/test/nginx-echo.conf
@@ -1,16 +1,12 @@
-
-user  nginx;
 worker_processes  1;
-load_module modules/ngx_http_echo_module.so;
+
+include modules/all.conf;
+
 daemon off;
-
-pid        /var/run/nginx.pid;
-
 
 events {
     worker_connections  1024;
 }
-
 
 http {
     include       /etc/nginx/mime.types;
@@ -20,14 +16,11 @@ http {
                       '$status $body_bytes_sent "$http_referer" '
                       '"$http_user_agent" "$http_x_forwarded_for"';
 
-
     server {
-        listen 80;
-        
+        listen 8080;
+
         location / {
             echo "nginx config check ok";
         }
     }
- 
-   
 }

--- a/test/nginx-tsuru.conf
+++ b/test/nginx-tsuru.conf
@@ -1,26 +1,12 @@
-
-user  nginx;
 worker_processes  1;
-load_module modules/ngx_http_echo_module.so;
-load_module modules/ngx_http_headers_more_filter_module.so;
-load_module modules/ngx_http_cache_purge_module.so;
-load_module modules/ndk_http_module.so;
-load_module modules/ngx_http_lua_module.so;
-load_module modules/ngx_http_vhost_traffic_status_module.so;
-load_module modules/ngx_http_fancyindex_module.so;
-load_module modules/ngx_http_push_stream_module.so;
-load_module modules/ngx_http_modsecurity_module.so;
 
+include modules/all.conf;
 
 daemon off;
-
-pid        /var/run/nginx.pid;
-
 
 events {
     worker_connections  1024;
 }
-
 
 http {
     push_stream_shared_memory_size 1M;
@@ -40,8 +26,9 @@ http {
     lua_package_path  "/usr/local/lib/lua/5.1/?.lua;;";
 
     server {
-        listen 80;
-        listen 443 ssl;
+        listen 8080;
+        listen 8443 ssl http2;
+
         ssl_certificate cert.pem;
         ssl_certificate_key key.pem;
         modsecurity on;
@@ -71,13 +58,11 @@ http {
         location ~ ^/purge/(.+) {
            proxy_cache_purge  cache_zone $1$is_args$args;
         }
-        
+
         location / {
             more_set_headers        'X-MyHeader: blah' 'X-MyHeader2: foo';
             modsecurity_rules_file  /etc/nginx/modsecurity_rules.conf;
             echo                    'nginx config check ok';
         }
     }
- 
-   
 }

--- a/test/nginx-tsuru.conf
+++ b/test/nginx-tsuru.conf
@@ -36,7 +36,9 @@ http {
     
     vhost_traffic_status_zone;
     vhost_traffic_status_histogram_buckets 0.002 0.005 0.01 0.02 0.05 0.1 0.2 0.5 1 2 5 10 15 20;
-    
+
+    lua_package_path  "/usr/local/lib/lua/5.1/?.lua;;";
+
     server {
         listen 80;
         listen 443 ssl;


### PR DESCRIPTION
This PR aims mainly to support TLS v1.3 into the NGINX web server, but it also provides some changes to improve performance and security at container images. 

* ~Build and install the OpenSSL 1.1.1c from source;~
* ~Rebuild NGINX to use the newer OpenSSL's version;~
* Update default NGINX version to 1.16.1;
* Fix the dynamic module building. Fetch all tags from source repository before checkout to a branch;
* Use OpenResty's LuaJIT branch;
* Include by default the Lua modules: lua-resty-core and lua-resty-lrucache.
	* Since resty.core is required at newer versions of Lua NGINX module. (see more at https://github.com/openresty/lua-nginx-module/issues/1509#issuecomment-486291741)
* Drop execution to unprivileged system user;
* Push to Docker Hub the NGINX's  stable and lastest versions;