### PR TITLE
Use `--recurse-submodules` when cloning module Git repos

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -59,7 +59,7 @@ RUN set -x \
         module_repo=$(echo $module | sed -E 's@^(((https?|git)://)?[^:]+).*@\1@g'); \
         module_tag=$(echo $module | sed -E 's@^(((https?|git)://)?[^:]+):?([^:/]*)@\4@g'); \
         dirname=$(echo "${module_repo}" | sed -E 's@^.*/|\..*$@@g'); \
-        git clone "${module_repo}"; \
+        git clone --recurse-submodules "${module_repo}"; \
         cd ${dirname}; \
         git fetch --tags; \
         if [ -n "${module_tag}" ]; then \


### PR DESCRIPTION
Some modules (like [`ngx_brotli`](https://github.com/google/ngx_brotli)) contain Git submodules. The current `Dockerfile` doesn't pull these submodules, which will cause the NGINX module build to fail. This PR ensures that when cloning NGINX module repos, submodules are cloned, too.