### PR TITLE
[BLOCKED] Add nginx 1.28

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,6 +9,7 @@ jobs:
       matrix:
         nginx:
         - "1.26.3"
+        - "1.28.1"
         flavor:
         - tsuru
         openresty_package_version:

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN set -x \
   && apt-get install -y --no-install-suggests \
   libluajit-5.1-dev libpam0g-dev zlib1g-dev libpcre2-dev \
   libexpat1-dev git curl build-essential lsb-release libxml2 libxslt1.1 libxslt1-dev autoconf libtool libssl-dev \
-  unzip libmaxminddb-dev libbrotli-dev cmake pkg-config libjansson-dev \
+  unzip libmaxminddb-dev libbrotli-dev cmake pkg-config libjansson-dev gnupg \
   && if [ "${NGINX_VERSION}" = "1.26.3" ]; then apt-get install -y --no-install-suggests libpcre3-dev; fi
 
 RUN git clone --depth 1 --branch cpp-3.1.0 https://github.com/msgpack/msgpack-c.git /home/msgpack

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,9 +6,10 @@ SHELL ["/bin/bash", "-c"]
 RUN set -x \
   && apt-get update \
   && apt-get install -y --no-install-suggests \
-  libluajit-5.1-dev libpam0g-dev zlib1g-dev libpcre3-dev libpcre2-dev \
+  libluajit-5.1-dev libpam0g-dev zlib1g-dev libpcre2-dev \
   libexpat1-dev git curl build-essential lsb-release libxml2 libxslt1.1 libxslt1-dev autoconf libtool libssl-dev \
-  unzip libmaxminddb-dev libbrotli-dev cmake pkg-config libjansson-dev
+  unzip libmaxminddb-dev libbrotli-dev cmake pkg-config libjansson-dev \
+  && if [ "${NGINX_VERSION}" = "1.26.3" ]; then apt-get install -y --no-install-suggests libpcre3-dev; fi
 
 RUN git clone --depth 1 --branch cpp-3.1.0 https://github.com/msgpack/msgpack-c.git /home/msgpack
 RUN cd /home/msgpack \

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,8 +24,9 @@ RUN mkdir -p /home/libjwt/build && \
 
 ARG openresty_package_version=1.27.1.1-1~bookworm1
 RUN set -x \
-  && curl -fsSL https://openresty.org/package/pubkey.gpg | apt-key add - \
-  && echo "deb https://openresty.org/package/$(uname -m | grep -qE 'aarch64|arm64' && echo -n 'arm64/')debian $(lsb_release -sc) openresty" | tee -a /etc/apt/sources.list.d/openresty.list \
+  && mkdir -p /etc/apt/keyrings \
+  && curl -fsSL https://openresty.org/package/pubkey.gpg | gpg --dearmor -o /etc/apt/keyrings/openresty.gpg \
+  && echo "deb [signed-by=/etc/apt/keyrings/openresty.gpg] https://openresty.org/package/$(uname -m | grep -qE 'aarch64|arm64' && echo -n 'arm64/')debian $(lsb_release -sc) openresty" | tee /etc/apt/sources.list.d/openresty.list \
   && apt-get update \
   && apt-get install -y --no-install-suggests openresty=${openresty_package_version} \
   && cd /usr/local/openresty \


### PR DESCRIPTION
We need to wait the openresty to release the version for debian trixie

the error found on CI:

```
The repository 'https://openresty.org/package/debian trixie Release' does not have a Release file.
``` 